### PR TITLE
add ghcr repo, build caching

### DIFF
--- a/.github/workflows/hub.yml
+++ b/.github/workflows/hub.yml
@@ -18,11 +18,26 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Set up build cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
         name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
       -
         name: Build and push
         uses: docker/build-push-action@v2
@@ -32,6 +47,10 @@ jobs:
           #platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
             akhilrex/podgrab:latest
             akhilrex/podgrab:1.0.0
+            ghcr.io/akhilrex/podgrab:latest
+            ghcr.io/akhilrex/podgrab:1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN go build -o ./app ./main.go
 
 FROM alpine:latest
 
+LABEL org.opencontainers.image.source="https://github.com/akhilrex/podgrab"
+
 ENV CONFIG=/config
 ENV DATA=/assets
 ENV UID=998


### PR DESCRIPTION
for ghcr image pushing, you need a github personal access token with permissions for read, write packages as seen here: 

https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images

create the token first in account settings and add it as a repository secret named GHCR_TOKEN

you may also want to start tagging releases in git so you can use the tags as image version tags

after first image publish, you also have to set it to public. it's private by default. 