### PR TITLE
Better filename sanitization

### DIFF
--- a/service/fileService.go
+++ b/service/fileService.go
@@ -289,7 +289,7 @@ func getFileName(link string, title string, defaultExtension string) string {
 }
 
 func cleanFileName(original string) string {
-	return sanitize.Name(original)
+	return sanitize.BaseName(original)
 }
 
 func checkError(err error) {


### PR DESCRIPTION
Using `sanitize.Name` can end up with file conflict when there are `/` in titles. Example include titles ending with `(1/2)` and `(2/2)` both being sanitize to `2)`. This changes it for `BaseName` which replace slashes with dashes instead of keeping only the last segment.