### PR TITLE
Send correct Content-Type for podcastitem

### DIFF
--- a/controllers/podcast.go
+++ b/controllers/podcast.go
@@ -289,7 +289,7 @@ func GetPodcastItemFileById(c *gin.Context) {
 				c.Header("Content-Description", "File Transfer")
 				c.Header("Content-Transfer-Encoding", "binary")
 				c.Header("Content-Disposition", "attachment; filename="+path.Base(podcast.DownloadPath))
-				c.Header("Content-Type", "application/octet-stream")
+				c.Header("Content-Type", GetFileContentType(podcast.DownloadPath))
 				c.File(podcast.DownloadPath)
 			} else {
 				c.Redirect(302, podcast.FileURL)
@@ -298,6 +298,19 @@ func GetPodcastItemFileById(c *gin.Context) {
 	} else {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
 	}
+}
+
+func GetFileContentType(filePath string) string {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "application/octet-stream"
+	}
+	defer file.Close()
+	buffer := make([]byte, 512)
+	if _, err := file.Read(buffer); err != nil {
+		return "application/octet-stream"
+	}
+	return http.DetectContentType(buffer)
 }
 
 func MarkPodcastItemAsUnplayed(c *gin.Context) {


### PR DESCRIPTION
Need to pass correct Content-Type because Safari won't play any sound passed as `application/octet-stream`.

Seems like `http.DetectContentType` supports most popular audio MIME types, so it should be fine. If any issues with it would come up, `http.DetectContentType` should be replaced with something more capable.

Fixes #83.