### PR TITLE
details card: rename 'Url' to 'Feed'

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -327,7 +327,7 @@
         <td>${ detailPodcast.Author }</td>
       </tr>
       <tr>
-        <td>Url</td>
+        <td>Feed</td>
         <td> <a target="_blank" :href="detailPodcast.URL">Link</a></td>
       </tr>
 


### PR DESCRIPTION
The feed link is not always a URL.
URL indicates, that the link is to the podcast's homepage, not feed.