### PR TITLE
Handle HTTP error responses when trying to download files

### DIFF
--- a/client/episodes.html
+++ b/client/episodes.html
@@ -252,6 +252,13 @@
                 position: "top-right",
                 duration: 5000,
               });
+            } else if (error.response && error.response.status) {
+              Vue.toasted.show("Download failed - something went wrong", {
+                theme: "bubble",
+                type: "error",
+                position: "top-right",
+                duration: 5000,
+              });
             }
           })
           .then(function () {});

--- a/service/fileService.go
+++ b/service/fileService.go
@@ -29,7 +29,7 @@ func Download(link string, episodeTitle string, podcastName string, prefix strin
 	client := httpClient()
 	resp, err := client.Get(link)
 	if err != nil {
-		Logger.Errorw("Error getting response: "+link, err)
+		Logger.Errorw("Error getting response: "+link, "error", err)
 		return "", err
 	}
 

--- a/service/fileService.go
+++ b/service/fileService.go
@@ -33,6 +33,16 @@ func Download(link string, episodeTitle string, podcastName string, prefix strin
 		return "", err
 	}
 
+	code := resp.StatusCode
+	if (400 <= code) && (code <= 499) {
+		Logger.Errorw("Host Rejected Download: "+link, "response", resp.Status)
+		return "", errors.New("" + resp.Status)
+	}
+	if (500 <= code) && (code <= 599) {
+		Logger.Errorw("Host Error: "+link, "response", resp.Status)
+		return "", errors.New(resp.Status)
+	}
+
 	fileName := getFileName(link, episodeTitle, ".mp3")
 	if prefix != "" {
 		fileName = fmt.Sprintf("%s-%s", prefix, fileName)


### PR DESCRIPTION
Hello, hoping to fix the behavior described in #170: 

* The content of responses with HTTP error codes are no longer saved (this is normally just text or some html)
* Episodes are no longer marked as downloaded but with an invalid file
* An error is shown to web UI users that there was a failure with details in the browser console