### PR TITLE
Fix podgrab spelling

### DIFF
--- a/controllers/podcast.go
+++ b/controllers/podcast.go
@@ -557,7 +557,7 @@ func GetRss(c *gin.Context) {
 	}
 
 	title := "Podgrab"
-	description := "Pograb playlist"
+	description := "Podgrab playlist"
 
 	c.XML(200, createRss(items, title, description, "", c))
 


### PR DESCRIPTION
I was looking at the generated RSS feed and noticed this minor spelling error.  Wasn't sure whether to mention it or submit a PR, but it is the project title that's misspelled.  