### PR TITLE
webassets, client: embed assets in compiled binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,6 @@ RUN chmod 777 /config; \
 
 WORKDIR /api
 COPY --from=builder /api/app .
-COPY client ./client
-COPY webassets ./webassets
 
 EXPOSE 8080
 

--- a/docs/ubuntu-install.md
+++ b/docs/ubuntu-install.md
@@ -6,7 +6,7 @@ This guide has been written with Ubuntu in mind. If you are using any other flav
 
 ## Install Go
 
-Podgrab is built using Go which would be needed to compile and build the source code. Podgrab is written with Go 1.15 so any version equal to or above this should be good to Go. 
+Podgrab is built using Go which would be needed to compile and build the source code. Podgrab is written with Go 1.16 so any version equal to or above this should be good to Go. 
 
 If you already have Go installed on your machine, you can skip to the next step.
 
@@ -31,8 +31,6 @@ git clone --depth 1 https://github.com/akhilrex/podgrab
 ``` bash
 cd podgrab
 mkdir -p ./dist
-cp -r client ./dist
-cp -r webassets ./dist
 cp .env ./dist
 go build -o ./dist/podgrab ./main.go
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/akhilrex/podgrab
 
-go 1.15
+go 1.16
 
 require (
 	github.com/TheHippo/podcastindex v1.0.0


### PR DESCRIPTION
Go 1.16 introduced the embed library, which allows for embedding files into the compiled binary. This simplifies deployment as only the executable is required on the host, without any separate web assets folders.

This patch applies this change to the client and webassets directories.