### PR TITLE
Fix missing application of user-agent setting

### DIFF
--- a/service/podcastService.go
+++ b/service/podcastService.go
@@ -715,6 +715,11 @@ func makeQuery(url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	
+	setting := db.GetOrCreateSetting()
+	if len(setting.UserAgent) > 0 {
+		req.Header.Add("User-Agent", setting.UserAgent)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Additional for #214.

One place where the user-agent setting was not applied, resulting in some podcasts failing to download still.  Creating a PR to highlight that this was missed as it is only mentioned in a comment on the previous PR.

credit to @wiseindy
https://github.com/wiseindy/podgrab