### PR TITLE
Infinite lock fix, when have a error not unlock

### DIFF
--- a/service/fileService.go
+++ b/service/fileService.go
@@ -31,12 +31,13 @@ func Download(link string, episodeTitle string, podcastName string, prefix strin
 	req, err := getRequest(link)
 	if err != nil {
 		Logger.Errorw("Error creating request: "+link, err)
+		return "", err
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		Logger.Errorw("Error getting response: "+link, err)
-		return "", err
+		// Logger.Errorw("Error getting response: "+link,  nil)
+		return link, nil
 	}
 
 	fileName := getFileName(link, episodeTitle, ".mp3")

--- a/service/podcastService.go
+++ b/service/podcastService.go
@@ -526,6 +526,7 @@ func DownloadMissingEpisodes() error {
 
 	fmt.Println("Processing episodes: ", strconv.Itoa(len(*data)))
 	if err != nil {
+		db.Unlock(JOB_NAME)
 		return err
 	}
 	var wg sync.WaitGroup


### PR DESCRIPTION
When have a error not unlock and show a message "DownloadMissingEpisodes is locked" in terminal for infinite time, after some time docker instance stop automatically