### PR TITLE
Add setting for max downloaded episodes per podcast

### DIFF
--- a/client/settings.html
+++ b/client/settings.html
@@ -108,6 +108,10 @@
             <span class="label-body">Limit the number of podcasts that can be downloaded simultaneously</span>
             <input type="number" name="maxDownloadConcurrency" v-model.number="maxDownloadConcurrency" min="1">
         </label>
+        <label for="maxDownloadKeep" style="display: inline-block;" >
+            <span class="label-body">Limit the number of podcast episodes that are kept (auto deletes older episodes beyond this number)</span>
+            <input type="number" name="maxDownloadKeep" v-model.number="maxDownloadKeep" min="1">
+        </label>
         <label for="userAgent" style="display: inline-block;" >
             <span class="label-body">The <code>User-Agent</code> header used when downloading podcasts</span>
             <input type="text" class="u-full-width" name="userAgent" v-model="userAgent">
@@ -190,6 +194,7 @@ var app = new Vue({
             dontDownloadDeletedFromDisk:self.dontDownloadDeletedFromDisk,
             baseUrl:self.baseUrl,
             maxDownloadConcurrency:self.maxDownloadConcurrency,
+            maxDownloadKeep:self.maxDownloadKeep,
             userAgent:self.userAgent,
         })
         .then(function(response){
@@ -236,6 +241,7 @@ var app = new Vue({
     dontDownloadDeletedFromDisk:{{ .setting.DontDownloadDeletedFromDisk }},
     baseUrl: {{ .setting.BaseUrl }},
     maxDownloadConcurrency:{{ .setting.MaxDownloadConcurrency }},
+    maxDownloadKeep:{{ .setting.MaxDownloadKeep }},
     userAgent:{{ .setting.UserAgent}},
   },
 

--- a/controllers/pages.go
+++ b/controllers/pages.go
@@ -32,6 +32,7 @@ type SettingModel struct {
 	DontDownloadDeletedFromDisk   bool   `form:"dontDownloadDeletedFromDisk" json:"dontDownloadDeletedFromDisk" query:"dontDownloadDeletedFromDisk"`
 	BaseUrl                       string `form:"baseUrl" json:"baseUrl" query:"baseUrl"`
 	MaxDownloadConcurrency        int    `form:"maxDownloadConcurrency" json:"maxDownloadConcurrency" query:"maxDownloadConcurrency"`
+	MaxDownloadKeep               int    `form:"maxDownloadKeep" json:"maxDownloadKeep" query:"maxDownloadKeep"`
 	UserAgent                     string `form:"userAgent" json:"userAgent" query:"userAgent"`
 }
 

--- a/controllers/podcast.go
+++ b/controllers/podcast.go
@@ -629,7 +629,7 @@ func UpdateSetting(c *gin.Context) {
 		err = service.UpdateSettings(model.DownloadOnAdd, model.InitialDownloadCount,
 			model.AutoDownload, model.AppendDateToFileName, model.AppendEpisodeNumberToFileName,
 			model.DarkMode, model.DownloadEpisodeImages, model.GenerateNFOFile, model.DontDownloadDeletedFromDisk, model.BaseUrl,
-			model.MaxDownloadConcurrency, model.UserAgent,
+			model.MaxDownloadConcurrency, model.MaxDownloadKeep, model.UserAgent,
 		)
 		if err == nil {
 			c.JSON(200, gin.H{"message": "Success"})

--- a/db/dbfunctions.go
+++ b/db/dbfunctions.go
@@ -165,7 +165,7 @@ func DeleteTagById(id string) error {
 
 func GetAllPodcastItemsByPodcastId(podcastId string, podcastItems *[]PodcastItem) error {
 
-	result := DB.Preload(clause.Associations).Where(&PodcastItem{PodcastID: podcastId}).Find(&podcastItems)
+	result := DB.Preload(clause.Associations).Where(&PodcastItem{PodcastID: podcastId}).Order("pub_date desc").Find(&podcastItems)
 	return result.Error
 }
 func GetAllPodcastItemsByPodcastIds(podcastIds []string, podcastItems *[]PodcastItem) error {

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -18,6 +18,10 @@ var migrations = []localMigration{
 		Name:  "2020_11_03_04_42_SetDefaultDownloadStatus",
 		Query: "update podcast_items set download_status=2 where download_path!='' and download_status=0",
 	},
+	{
+		Name: "2023_10_17_AddMaxDownloadKeepColumn",
+		Query: "ALTER TABLE settings ADD max_download_keep INT default 5",
+	},
 }
 
 func RunMigrations() {

--- a/db/podcast.go
+++ b/db/podcast.go
@@ -89,6 +89,7 @@ type Setting struct {
 	BaseUrl                       string
 	MaxDownloadConcurrency        int `gorm:"default:5"`
 	UserAgent                     string
+	MaxDownloadKeep               int `gorm:"default:5"`
 }
 type Migration struct {
 	Base

--- a/main.go
+++ b/main.go
@@ -230,6 +230,7 @@ func intiCron() {
 	gocron.Every(uint64(checkFrequency) * 2).Minutes().Do(service.UnlockMissedJobs)
 	gocron.Every(uint64(checkFrequency) * 3).Minutes().Do(service.UpdateAllFileSizes)
 	gocron.Every(uint64(checkFrequency)).Minutes().Do(service.DownloadMissingImages)
+	gocron.Every(uint64(checkFrequency)).Minutes().Do(service.ClearEpisodeFiles)
 	gocron.Every(2).Days().Do(service.CreateBackup)
 	<-gocron.Start()
 }


### PR DESCRIPTION
Added an option for setting a maximum number of episodes to have downloaded at a time. So you can keep a rolling set of the most recent 5 episodes downloaded.