### PR TITLE
Add support for MP3 tagging and update settings structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV PID=100
 ENV GIN_MODE=release
 VOLUME ["/config", "/assets"]
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk add --no-cache python3 py3-pip && pip3 install eyeD3 --break-system-packages
 RUN mkdir -p /config; \
     mkdir -p /assets; \
     mkdir -p /api

--- a/client/settings.html
+++ b/client/settings.html
@@ -96,6 +96,10 @@
             <input type="checkbox" name="generateNFOFile" v-model="generateNFOFile">
             <span class="label-body">Generate NFO files for Podcasts</span>
         </label>
+        <label for="enableMp3Tagging">
+            <input type="checkbox" name="enableMp3Tagging" v-model="enableMp3Tagging">
+            <span class="label-body">Enable tagging of Artist(<em>Podcast Title) and Track#(<em>Episode#</em>)</span>
+        </label>
         <label for="dontDownloadDeletedFromDisk">
             <input type="checkbox" name="dontDownloadDeletedFromDisk" v-model="dontDownloadDeletedFromDisk">
             <span class="label-body">Don't re-download files deleted from disk.</span>
@@ -112,7 +116,7 @@
             <span class="label-body">The <code>User-Agent</code> header used when downloading podcasts</span>
             <input type="text" class="u-full-width" name="userAgent" v-model="userAgent">
         </label>
-      
+        
         <input type="submit" value="Save" class="button">
     </form>
 </div>
@@ -187,6 +191,7 @@ var app = new Vue({
             darkMode:self.darkMode,
             downloadEpisodeImages:self.downloadEpisodeImages,
             generateNFOFile:self.generateNFOFile,
+            enableMp3Tagging: self.enableMp3Tagging,
             dontDownloadDeletedFromDisk:self.dontDownloadDeletedFromDisk,
             baseUrl:self.baseUrl,
             maxDownloadConcurrency:self.maxDownloadConcurrency,
@@ -233,10 +238,12 @@ var app = new Vue({
     originalThemeSetting:{{ .setting.DarkMode }},
     downloadEpisodeImages:{{.setting.DownloadEpisodeImages }},
     generateNFOFile:{{ .setting.GenerateNFOFile }},
+    enableMp3Tagging: {{ .setting.EnableMp3Tagging }},
     dontDownloadDeletedFromDisk:{{ .setting.DontDownloadDeletedFromDisk }},
     baseUrl: {{ .setting.BaseUrl }},
     maxDownloadConcurrency:{{ .setting.MaxDownloadConcurrency }},
     userAgent:{{ .setting.UserAgent}},
+    
   },
 
 })

--- a/controllers/pages.go
+++ b/controllers/pages.go
@@ -33,6 +33,7 @@ type SettingModel struct {
 	BaseUrl                       string `form:"baseUrl" json:"baseUrl" query:"baseUrl"`
 	MaxDownloadConcurrency        int    `form:"maxDownloadConcurrency" json:"maxDownloadConcurrency" query:"maxDownloadConcurrency"`
 	UserAgent                     string `form:"userAgent" json:"userAgent" query:"userAgent"`
+	EnableMp3Tagging              bool   `form:"enableMp3Tagging" json:"enableMp3Tagging" query:"enableMp3Tagging"`
 }
 
 var searchOptions = map[string]string{

--- a/controllers/podcast.go
+++ b/controllers/podcast.go
@@ -628,7 +628,7 @@ func UpdateSetting(c *gin.Context) {
 
 		err = service.UpdateSettings(model.DownloadOnAdd, model.InitialDownloadCount,
 			model.AutoDownload, model.AppendDateToFileName, model.AppendEpisodeNumberToFileName,
-			model.DarkMode, model.DownloadEpisodeImages, model.GenerateNFOFile, model.DontDownloadDeletedFromDisk, model.BaseUrl,
+			model.DarkMode, model.DownloadEpisodeImages, model.GenerateNFOFile, model.EnableMp3Tagging, model.DontDownloadDeletedFromDisk, model.BaseUrl,
 			model.MaxDownloadConcurrency, model.UserAgent,
 		)
 		if err == nil {

--- a/db/podcast.go
+++ b/db/podcast.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-//Podcast is
+// Podcast is
 type Podcast struct {
 	Base
 	Title string
@@ -34,7 +34,7 @@ type Podcast struct {
 	IsPaused bool `gorm:"default:false"`
 }
 
-//PodcastItem is
+// PodcastItem is
 type PodcastItem struct {
 	Base
 	PodcastID string
@@ -85,6 +85,7 @@ type Setting struct {
 	DarkMode                      bool `gorm:"default:false"`
 	DownloadEpisodeImages         bool `gorm:"default:false"`
 	GenerateNFOFile               bool `gorm:"default:false"`
+	EnableMp3Tagging              bool `gorm:"default:true"`
 	DontDownloadDeletedFromDisk   bool `gorm:"default:false"`
 	BaseUrl                       string
 	MaxDownloadConcurrency        int `gorm:"default:5"`


### PR DESCRIPTION
- Introduced 'EnableMp3Tagging' option in settings
- Updated Dockerfile to install eyeD3 for ID3 tagging
- Modified relevant functions to handle MP3 tagging after downloads. Specifically setting Artist and Track#.