### PR TITLE
fix: use custom user-agent and add Accept headers when fetching rss

### DIFF
--- a/service/fileService.go
+++ b/service/fileService.go
@@ -355,6 +355,8 @@ func getRequest(url string) (*http.Request, error) {
 		req.Header.Add("User-Agent", setting.UserAgent)
 	}
 
+	req.Header.Add("Accept", "*/*")
+
 	return req, nil
 }
 

--- a/service/podcastService.go
+++ b/service/podcastService.go
@@ -716,6 +716,13 @@ func makeQuery(url string) ([]byte, error) {
 		return nil, err
 	}
 
+	setting := db.GetOrCreateSetting()
+	if len(setting.UserAgent) > 0 {
+		req.Header.Add("User-Agent", setting.UserAgent)
+	}
+
+	req.Header.Add("Accept", "*/*")
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously the configured custom user agent was only used when downloading files and not the actual podcast feed RSS, this commit fixes that (user agent is applied in both cases). Also added an `Accept: */*` header, since a lot of servers give 403/forbidden or other opaque errors when its missing.

This fixes several feeds for me and likely addresses these issues (and maybe more):

closes #303, closes #225, closes #182, closes #313, closes #312

If anyone wishes to use this patch prior to being merged (as it seems development has slowed or stalled here), I have published a podgrab image with this patch applied that you can use as a drop-in replacement for the official docker image at `ghcr.io/rudism/podgrab:latest`